### PR TITLE
update sqlalchemy 0.9 to 1.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: xenial
+
 language: python
 python:
     - "2.7"
@@ -6,7 +8,7 @@ jdk:
   - oraclejdk7
 
 addons:
-  postgresql: '9.4'
+  postgresql: '9.6'
 
 before_script:
   - "echo $JAVA_OPTS"
@@ -14,5 +16,6 @@ before_script:
   - echo -e 'Host github.com\n\tStrictHostKeyChecking no\n' >> ~/.ssh/config
   - pip uninstall --yes psqlgraph || true
   - yes | python setup.py install
-  - cd test; python setup_test_psqlgraph.py
-script: "cd test; py.test -v"
+  - pip list
+  - cd test; python setup_test_psqlgraph.py; cd ..
+script: "py.test -v test"

--- a/psqlgraph/base.py
+++ b/psqlgraph/base.py
@@ -1,6 +1,6 @@
 from attributes import PropertiesDict, SystemAnnotationDict
 from sqlalchemy import Column, Text, DateTime, text, event
-from sqlalchemy.dialects.postgres import ARRAY, JSONB
+from sqlalchemy.dialects.postgresql import ARRAY, JSONB
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.ext.declarative import declared_attr
 from sqlalchemy.ext.hybrid import hybrid_property

--- a/psqlgraph/base.py
+++ b/psqlgraph/base.py
@@ -14,6 +14,14 @@ NODE_TABLENAME_SCHEME = 'node_{class_name}'
 EDGE_TABLENAME_SCHEME = 'edge_{class_name}'
 
 
+class _label_property(object):
+
+    def __init__(self, fget):
+        self.fget = fget
+
+    def __get__(self, instance, owner):
+        return self.fget(owner)
+
 class CommonBase(object):
 
     _session_hooks_before_insert = []
@@ -51,9 +59,15 @@ class CommonBase(object):
         default={},
     )
 
+
     @classmethod
     def get_label(cls):
         return getattr(cls, '__label__', cls.__name__.lower())
+
+    @_label_property
+    def label(cls):
+        return cls.get_label()
+
 
     # ======== Table Attributes ========
     @declared_attr
@@ -179,25 +193,6 @@ class CommonBase(object):
         """
         return key in cls.get_property_list()
 
-    # ======== Label ========
-    @hybrid_property
-    def label(self):
-        """Custom label on the model
-
-        .. note: This is not the polymorphic identity, see `_type`
-        """
-        return self.get_label()
-
-    @label.setter
-    def label(self, label):
-        """Custom setter as an application level ban from changing labels.
-
-        """
-        if not isinstance(self.label, Column)\
-           and self.get_label() is not None\
-           and self.get_label() != label:
-            raise AttributeError('Cannot change label from {} to {}'.format(
-                self.get_label(), label))
 
     # ======== System Annotations ========
     @hybrid_property

--- a/psqlgraph/base.py
+++ b/psqlgraph/base.py
@@ -60,13 +60,7 @@ class CommonBase(object):
     def __mapper_args__(cls):
         name = cls.__name__
         if name in abstract_classes:
-            pjoin = polymorphic_union({
-                scls.__tablename__: scls.__table__ for scls in
-                cls.get_subclasses()}, 'type')
-            return {
-                'polymorphic_identity': name,
-                'with_polymorphic': ('*', pjoin),
-            }
+            return {}
         else:
             return {
                 'polymorphic_identity': name,

--- a/psqlgraph/base.py
+++ b/psqlgraph/base.py
@@ -14,14 +14,6 @@ NODE_TABLENAME_SCHEME = 'node_{class_name}'
 EDGE_TABLENAME_SCHEME = 'edge_{class_name}'
 
 
-class _label_property(object):
-
-    def __init__(self, fget):
-        self.fget = fget
-
-    def __get__(self, instance, owner):
-        return self.fget(owner)
-
 class CommonBase(object):
 
     _session_hooks_before_insert = []
@@ -58,15 +50,6 @@ class CommonBase(object):
         JSONB,
         default={},
     )
-
-
-    @classmethod
-    def get_label(cls):
-        return getattr(cls, '__label__', cls.__name__.lower())
-
-    @_label_property
-    def label(cls):
-        return cls.get_label()
 
 
     # ======== Table Attributes ========
@@ -192,6 +175,16 @@ class CommonBase(object):
 
         """
         return key in cls.get_property_list()
+
+
+    # ======== Label  ========
+    @classmethod
+    def get_label(cls):
+        return getattr(cls, '__label__', cls.__name__.lower())
+
+    @declared_attr
+    def label(cls):
+        return cls.get_label()
 
 
     # ======== System Annotations ========

--- a/psqlgraph/edge.py
+++ b/psqlgraph/edge.py
@@ -216,22 +216,6 @@ class Edge(AbstractConcreteBase, ORMBase, CheckAttributesMixin):
         voided = VoidedEdge(temp)
         session.add(voided)
 
-    # ======== Label ========
-    @hybrid_property
-    def label(self):
-        return self.get_label()
-
-    @label.setter
-    def label(self, label):
-        """Custom setter as an application level ban from changing labels.
-
-        """
-        if not isinstance(self.label, Column)\
-           and self.get_label() is not None\
-           and self.get_label() != label:
-            raise AttributeError('Cannot change label from {} to {}'.format(
-                self.get_label(), label))
-
 
 def PolyEdge(src_id=None, dst_id=None, label=None, acl=[],
              system_annotations={}, properties={}):

--- a/psqlgraph/edge.py
+++ b/psqlgraph/edge.py
@@ -20,7 +20,22 @@ def IDColumn(tablename):
     )
 
 
-class Edge(AbstractConcreteBase, ORMBase):
+class CheckAttributesMixin:
+    @classmethod
+    def __declare_last__(cls):
+        if cls == Edge:
+            return
+        assert hasattr(cls, '__src_class__'),\
+            'You must declare __src_class__ for {}'.format(cls)
+        assert hasattr(cls, '__dst_class__'),\
+            'You must declare __dst_class__ for {}'.format(cls)
+        assert hasattr(cls, '__src_dst_assoc__'),\
+            'You must declare __src_dst_assoc__ for {}'.format(cls)
+        assert hasattr(cls, '__dst_src_assoc__'),\
+            'You must declare __dst_src_assoc__ for {}'.format(cls)
+
+
+class Edge(AbstractConcreteBase, ORMBase, CheckAttributesMixin):
 
     __src_table__ = None
     __dst_table__ = None
@@ -44,19 +59,6 @@ class Edge(AbstractConcreteBase, ORMBase):
             class_name=cls.__dst_class__.lower())
         dst_id = IDColumn(dst_table)
         return dst_id
-
-    @classmethod
-    def __declare_last__(cls):
-        if cls == Edge:
-            return
-        assert hasattr(cls, '__src_class__'),\
-            'You must declare __src_class__ for {}'.format(cls)
-        assert hasattr(cls, '__dst_class__'),\
-            'You must declare __dst_class__ for {}'.format(cls)
-        assert hasattr(cls, '__src_dst_assoc__'),\
-            'You must declare __src_dst_assoc__ for {}'.format(cls)
-        assert hasattr(cls, '__dst_src_assoc__'),\
-            'You must declare __dst_src_assoc__ for {}'.format(cls)
 
     @declared_attr
     def __table_args__(cls):

--- a/psqlgraph/edge.py
+++ b/psqlgraph/edge.py
@@ -69,7 +69,10 @@ class Edge(AbstractConcreteBase, ORMBase):
 
     @declared_attr
     def __tablename__(cls):
-        return EDGE_TABLENAME_SCHEME.format(class_name=cls.__name__.lower())
+        if cls.__name__ == 'Edge':
+            return None
+        else:
+            return EDGE_TABLENAME_SCHEME.format(class_name=cls.__name__.lower())
 
     def __init__(self, src_id=None, dst_id=None, properties={},
                  acl=[], system_annotations={}, label=None,

--- a/psqlgraph/node.py
+++ b/psqlgraph/node.py
@@ -17,8 +17,43 @@ def reverse_lookup(dictionary, search_val):
         if val == search_val:
             yield key
 
+class LinkEdgeMixin:
+    @classmethod
+    def __declare_last__(cls):
+        src_ids, dst_ids = [], []
+        for scls in Edge.get_subclasses():
+            name = scls.__name__
+            name_in = '_{}_in'.format(name)
+            name_out = '_{}_out'.format(name)
+            src_assoc = getattr(scls, SRC_DST_ASSOC)
+            dst_assoc = getattr(scls, DST_SRC_ASSOC)
+            if scls.__dst_class__ == cls.__name__:
+                if not hasattr(cls, name_in):
+                    edge_in = relationship(
+                        name,
+                        foreign_keys=[scls.dst_id],
+                        backref='dst',
+                        cascade='all, delete, delete-orphan',
+                    )
+                    setattr(cls, name_in, edge_in)
+                    cls._edges_in.append(name_in)
+                    dst_ids.append(scls.dst_id)
+                cls._set_association_proxy(scls, dst_assoc, name_in, 'src')
+            if scls.__src_class__ == cls.__name__:
+                if not hasattr(cls, name_out):
+                    edge_out = relationship(
+                        name,
+                        foreign_keys=[scls.src_id],
+                        backref='src',
+                        cascade='all, delete, delete-orphan',
+                    )
+                    setattr(cls, name_out, edge_out)
+                    cls._edges_out.append(name_out)
+                    src_ids.append(scls.src_id)
+                cls._set_association_proxy(scls, src_assoc, name_out, 'dst')
 
-class Node(AbstractConcreteBase, ORMBase):
+
+class Node(AbstractConcreteBase, ORMBase, LinkEdgeMixin):
 
     @declared_attr
     def _edges_out(self):
@@ -63,39 +98,6 @@ class Node(AbstractConcreteBase, ORMBase):
     def edges_out(self):
         return [e for rel in self._edges_out for e in getattr(self, rel)]
 
-    @classmethod
-    def __declare_last__(cls):
-        src_ids, dst_ids = [], []
-        for scls in Edge.get_subclasses():
-            name = scls.__name__
-            name_in = '_{}_in'.format(name)
-            name_out = '_{}_out'.format(name)
-            src_assoc = getattr(scls, SRC_DST_ASSOC)
-            dst_assoc = getattr(scls, DST_SRC_ASSOC)
-            if scls.__dst_class__ == cls.__name__:
-                if not hasattr(cls, name_in):
-                    edge_in = relationship(
-                        name,
-                        foreign_keys=[scls.dst_id],
-                        backref='dst',
-                        cascade='all, delete, delete-orphan',
-                    )
-                    setattr(cls, name_in, edge_in)
-                    cls._edges_in.append(name_in)
-                    dst_ids.append(scls.dst_id)
-                cls._set_association_proxy(scls, dst_assoc, name_in, 'src')
-            if scls.__src_class__ == cls.__name__:
-                if not hasattr(cls, name_out):
-                    edge_out = relationship(
-                        name,
-                        foreign_keys=[scls.src_id],
-                        backref='src',
-                        cascade='all, delete, delete-orphan',
-                    )
-                    setattr(cls, name_out, edge_out)
-                    cls._edges_out.append(name_out)
-                    src_ids.append(scls.src_id)
-                cls._set_association_proxy(scls, src_assoc, name_out, 'dst')
 
     @classmethod
     def _set_association_proxy(cls, edge_cls, attr_name, edge_name, direction):

--- a/psqlgraph/node.py
+++ b/psqlgraph/node.py
@@ -17,6 +17,7 @@ def reverse_lookup(dictionary, search_val):
         if val == search_val:
             yield key
 
+
 class LinkEdgeMixin:
     @classmethod
     def __declare_last__(cls):
@@ -97,7 +98,6 @@ class Node(AbstractConcreteBase, ORMBase, LinkEdgeMixin):
     @hybrid_property
     def edges_out(self):
         return [e for rel in self._edges_out for e in getattr(self, rel)]
-
 
     @classmethod
     def _set_association_proxy(cls, edge_cls, attr_name, edge_name, direction):

--- a/psqlgraph/node.py
+++ b/psqlgraph/node.py
@@ -36,7 +36,10 @@ class Node(AbstractConcreteBase, ORMBase):
 
     @declared_attr
     def __tablename__(cls):
-        return NODE_TABLENAME_SCHEME.format(class_name=cls.__name__.lower())
+        if cls.__name__ == 'Node':
+            return None
+        else:
+            return NODE_TABLENAME_SCHEME.format(class_name=cls.__name__.lower())
 
     @declared_attr
     def __table_args__(cls):

--- a/psqlgraph/node.py
+++ b/psqlgraph/node.py
@@ -119,7 +119,6 @@ class Node(AbstractConcreteBase, ORMBase, LinkEdgeMixin):
         self._props = {}
         self.system_annotations = system_annotations
         self.acl = acl
-        self.label = label or self.get_label()
         self.properties = properties
         self.properties.update(kwargs)
         self.node_id = node_id

--- a/psqlgraph/voided_edge.py
+++ b/psqlgraph/voided_edge.py
@@ -10,6 +10,7 @@ class VoidedEdge(VoidedBase):
     key = Column(
         BigInteger,
         primary_key=True,
+        autoincrement=True,
         nullable=False
     )
 

--- a/psqlgraph/voided_edge.py
+++ b/psqlgraph/voided_edge.py
@@ -1,4 +1,4 @@
-from sqlalchemy.dialects.postgres import ARRAY, JSONB
+from sqlalchemy.dialects.postgresql import ARRAY, JSONB
 from sqlalchemy import Column, Text, DateTime, BigInteger, text
 from base import VoidedBase
 

--- a/psqlgraph/voided_node.py
+++ b/psqlgraph/voided_node.py
@@ -10,6 +10,7 @@ class VoidedNode(VoidedBase):
     key = Column(
         BigInteger,
         primary_key=True,
+        autoincrement=True,
         nullable=False
     )
 

--- a/psqlgraph/voided_node.py
+++ b/psqlgraph/voided_node.py
@@ -1,4 +1,4 @@
-from sqlalchemy.dialects.postgres import ARRAY, JSONB
+from sqlalchemy.dialects.postgresql import ARRAY, JSONB
 from sqlalchemy import Column, Text, DateTime, BigInteger, text
 from base import VoidedBase
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     packages=["psqlgraph"],
     install_requires=[
         'psycopg2==2.7.3.2',
-        'sqlalchemy==0.9.9',
+        'sqlalchemy~=1.3.3',
         'py2neo==2.0.1',
         'progressbar',
         'avro==1.7.7',

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     packages=["psqlgraph"],
     install_requires=[
         'psycopg2==2.7.3.2',
-        'sqlalchemy~=1.3.3',
+        'sqlalchemy~=1.3',
         'py2neo==2.0.1',
         'progressbar',
         'avro==1.7.7',


### PR DESCRIPTION
The mission is to bump sqlalchemy from 0.9 to 1.3. There is an assortment of problems. Here's what this PR is doing and why: 

## Make label a declared_attr instead of a hybrid_property

Previously psqlgraph's `CommonBase` class had a `label` attribute decorated with SQLAlchemy's `hybrid_property`. SQLAlchemy 1.1 [reworks](https://docs.sqlalchemy.org/en/11/changelog/migration_11.html#hybrid-properties-and-methods-now-propagate-the-docstring-as-well-as-info) hybrid properties such that the expression returned by the class-level accessor is wrapped inside a QueryableAttribute wrapper. So `cls.label` is no longer just a string and ~all~ most of the code treating it as such is broken. (It is a string-like object, so things like `if cls.label == "something"` are not broken, but things like `gql_object = type(cls.label, blah, blah)` are.)

Using `cls().label` instead is obviously not the greatest solution. Then there's the classmethod `get_label()`, but this only works until (in Peregrine) Graphene tries to make the schema/typemap and there's no way to pass it strings from `get_label()` instead of the attribute `cls.label`; moreover this misses the point that we want `label` to behave like an attribute. 

In any case, sqlalchemy's `hybrid_property` is supposed to be used to define custom SQL expressions for class-level accesses of a property, and psqlgraph is doing no such thing with `label`. It turns out sqlalchemy's [`declared_attr`](https://docs.sqlalchemy.org/en/13/orm/extensions/declarative/api.html#sqlalchemy.ext.declarative.declared_attr) is a much better match ("Mark a class-level method as representing the definition of a mapped property or special declarative member name[...] @declared_attr turns the attribute into a scalar-like property that can be invoked from the uninstantiated class"), so we change `label` to that instead. This also happens to prevent manual setting of the attribute, so we can remove our own custom `label.setter` that exists for that purpose. 

## Move __declare_last__ functions to mixin classes

psqlgraph programmatically creates relationships and association proxies on each concrete Node, to the appropriate Edges, by way of the `__declare_last__` hook. 

Previously in sqlalchemy 0.9, the declarative base code would [check each of a class's parents for](https://github.com/sqlalchemy/sqlalchemy/blob/04da2878d1945dcf3ac074c386c9690ed380e672/lib/sqlalchemy/ext/declarative/base.py#L50-L56) `__declare_last__` and, if found, registers the `cls.__declare_last__` listener to the mapper's `after_configured` event. 

Now in sqlalchemy 1.3, the hook [is only](https://github.com/sqlalchemy/sqlalchemy/blob/171d6916c64416c24f81518cab5e2cd325ae449d/lib/sqlalchemy/ext/declarative/base.py#L195-L200) registered [if `__declare_last__` is](https://github.com/sqlalchemy/sqlalchemy/blob/171d6916c64416c24f81518cab5e2cd325ae449d/lib/sqlalchemy/ext/declarative/base.py#L86-L90) "either present directly on the class, e.g. not on a superclass, or is from a superclass but this superclass is a non-mapped mixin, that is, not a descendant of the declarative base and is also not classically mapped". 

Since in psqlgraph `__declare_last__` was defined on `Node` which moreover inherited from `ORMBase = declarative_base(cls=CommonBase)`, updating to 1.3 meant the hook was no longer registered and `__declare_last__` no longer got invoked for the concrete Nodes. 

Obviously we cannot define `__declare_last__` directly on the concrete Nodes that we are dynamically generating. So now in both `Node` and `Edge` there is no longer a `__declare_last__`, and instead those functions have been moved into their own classes that are then inherited by `Node` and `Edge` as mixins. 

## Remove __mapper_args__ from CommonBase

TLDR: If you use `AbstractConcreteBase` then the abstract base class gets mapped to the union of its derivatives; this is new; it broke psqlgraph polymorphic loading/querying; fix it by not providing a custom SELECT in the mapper args on the abstract base.

Background reading, for my own benefit...: 
- The various "polymorphic" keyword arguments specified in `__mapper_args__` are used to [configure inheritance](https://docs.sqlalchemy.org/en/13/orm/extensions/declarative/inheritance.html#) in general. 
- In particular, [concrete table inheritance](https://docs.sqlalchemy.org/en/13/orm/extensions/declarative/inheritance.html#concrete-table-inheritance) with an abstract base class requires usage of `polymorphic_union()`. 
- [Polymorphic loading](https://docs.sqlalchemy.org/en/13/orm/inheritance_loading.html#) is the default behavior for all inheritance configurations; `with_polymorphic` is used to enable eager loading on the subclass attributes. You can [configure this on the mapper](https://docs.sqlalchemy.org/en/13/orm/inheritance_loading.html#setting-with-polymorphic-at-mapper-configuration-time); using Declarative style means you have to specify `'polymorphic_load': 'inline'` on the concrete classes. 
- [Concrete inheritance when coupled with polymorphic loading](https://docs.sqlalchemy.org/en/13/orm/inheritance.html#concrete-table-inheritance) requires a custom SELECT to be used in the mapper. 
- [Concrete inheritance with an abstract base class coupled with polymorphic loading](https://docs.sqlalchemy.org/en/13/orm/inheritance.html#abstract-concrete-classes) is achieved by using the `AbstractConcreteBase` helper class, which just maps the abstract base class to the polymorphic union(!), as opposed to specifying a custom join/union as a `with_polymorphic` argument in the mapper configuration. 

So, in psqlgraph... 

- Currently the `CommonBase` class... specifies a custom union as a `with_polymorphic` argument in the mapper configuration (in the case where it is the abstract base being configured). But the `Node` class also inherits from `AbstractConcreteBase`. 
- A query on `Node` in sqlalchemy 1.3 now produces different SQL than it did on 0.9. In particular, where the query used to be just "select from the union of all the concrete classes" as desired, now the abstract base class is being rendered as the union of all the concrete classes--twice--once aliased as pjoin (that's us) and once as p_union [(a sqlalchemy default)](https://docs.sqlalchemy.org/en/13/orm/mapping_api.html#sqlalchemy.orm.util.polymorphic_union). And then these are JOINed to the concrete classes, resulting in an empty set. 
- So we just remove our custom UNION from the `__mapper_args__` on `CommonBase` and let the new `AbstractConcreteBase` do its mapping then the query is back to normal. 


## Return __tablename__ = None if abstract class 

[Previously](https://github.com/sqlalchemy/sqlalchemy/blob/04da2878d1945dcf3ac074c386c9690ed380e672/lib/sqlalchemy/ext/declarative/base.py#L61-L64) the sqlalchemy logic for `AbstractConcreteBase` was to check the class `__mro__` when determining whether to actually make a table or not. [Now (as of 1.0)](https://github.com/sqlalchemy/sqlalchemy/blob/6bd5d6526a3a7773f21869224f0eea2932a518ae/lib/sqlalchemy/ext/declarative/base.py#L376) it checks if `__tablename__`. So in the abstract base classes `Edge` and `Node` we are now doing: 
```
        if cls.__name__ == '[Edge or Node]':
            return None
        else:
            return EDGE_TABLENAME_SCHEME.format(class_name=cls.__name__.lower())
```

## Set autoincrement on key column in _voided_edges table

https://docs.sqlalchemy.org/en/11/changelog/migration_11.html#the-autoincrement-directive-is-no-longer-implicitly-enabled-for-a-composite-primary-key-column

So we add `autoincrement=True` to `key` in `_voided_edges`. The end result is that the table stays the same after the sqlalch bump: the `key` column on the `_voided_edges` table will autoincrement as before. (The `key` column is part of a composite primary key for `_voided_edges`: `"_voided_edges_pkey" PRIMARY KEY, btree (key, src_id, dst_id, label)`.) 

Note: For some reason, for `_voided_nodes` there is not a similar composite primary key, even though `_voided_nodes` has `node_id` and `label` columns--instead the key is just `"_voided_nodes_pkey" PRIMARY KEY, btree (key)`. This PR adds `autoincrement=True` anyway to the `key` column definition on `_voided_nodes`. That way the behaviour will stay the same (autoincrement is already implicitly true), but if someone decides to make this pkey composite in future, they will avoid this problem. Since this is just a "bump sqlalchemy" PR, I'll leave the `_voided_nodes` pkey noncomposite. 

## Import dialects.postgresql, not postgres 
postgres dialect renamed postgresql in sqlalchemy 0.6: 
https://docs.sqlalchemy.org/en/13/changelog/changelog_06.html#change-0ce9ee480a5a66cb9f77e0207f6dfc70

In 1.1 "postgres" is finally being removed:
https://docs.sqlalchemy.org/en/13/changelog/migration_11.html#the-postgres-module-is-removed 

So we are (finally) fixing the imports. 

---

### Dependency updates
bump sqlalchemy from 0.9 to 1.3

### Breaking Changes
bumps sqlalchemy from 0.9 to 1.3, so will not work with <1.3; see https://github.com/uc-cdis/psqlgraph/pull/3 for details