### PR TITLE
PyPI release, gen3git

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,9 @@ env:
   global:
   - PIPENV_IGNORE_VIRTUALENVS=1
   - secure: OADcVWEZgkVtRduIDbuyXBVBoEeJJCJZ/yGqLK+uU4ziM+CJ7AxEHbOgKENpkbUXEvrTz1CnNt//CAKGXZnPU0mBLvCB0sD1WvO3ITNcufqxUBceEAyrrjMEwrQ51fHTSzWxfaHYcqFGsxHonHOsS/hLuRshgGgc8HT5Yu39WBtiTG6SCvKAsq7GYuk4PQ6vK44g5YVZqzur9zyXcUdFmv+GBBHVfXlTGwzd9CMfx+o0sqpD9KcAxMCIfoxL/ReGM3KihFy+WgID9gmlH6tq18RnKrtLZbHgPO5395HPZoKpy+HWJtCOf1Q/luvCPo+DI4LYhU9o/WOOSPK4hb06IUOMYlxDf0LKo3P85P2lGhM3RLpiKF6+YB+EjLdld1LCFHPMRi3QG6pUAH6Jg3+9Iko3ry2QCNFMGxOmfdc8vYefXanSi7++MxevKONQdAb2rcz+XK/5bLXWWzPbs4QC0y+c6GzcayQwHDrlrf5kvHBC27zy/kW8oW7iQlN+4UgddZeUBjiSm7bdWNt2D1r522vMz6W+9JU3dNLcHoBiNm3dJVFbOV3RX4RaJdNnUUX9FMeS4xpBV1/keR2d3wZxFQjf4/uQq6/crOtBExtxwaZSPt+R0/JRCtQcQYxU9uum2ezVmFhjzFkKgsW3dDVQFja9Hxp1bc0G/tBs2vfhlUc=
-after_deploy:
-- pipenv run pip install gen3git
-- pipenv run gen3git release
+# gen3git release will try to pull old commits instead of just commits since last tag.
+# Need to fix this (PXP-3383), then can uncomment after_deploy section
+# For now just manually generate release notes.
+#after_deploy:
+#- pipenv run pip install gen3git
+#- pipenv run gen3git release

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,42 @@
 dist: xenial
-
 language: python
 python:
-    - "2.7"
-# command to run tests
+- '2.7'
 jdk:
-  - oraclejdk7
-
+- oraclejdk7
 addons:
   postgresql: '9.6'
-
+install:
+- pip uninstall --yes psqlgraph || true
+- pip install pipenv
+- pipenv install --dev --deploy --python `which python`
+- pipenv graph
 before_script:
-  - "echo $JAVA_OPTS"
-  - "export JAVA_OPTS=-Xmx512m"
-  - echo -e 'Host github.com\n\tStrictHostKeyChecking no\n' >> ~/.ssh/config
-  - pip uninstall --yes psqlgraph || true
-  - yes | python setup.py install
-  - pip list
-  - cd test; python setup_test_psqlgraph.py; cd ..
-script: "py.test -v test"
+- echo $JAVA_OPTS
+- export JAVA_OPTS=-Xmx512m
+- echo -e 'Host github.com\n\tStrictHostKeyChecking no\n' >> ~/.ssh/config
+- pipenv run python test/setup_test_psqlgraph.py
+script: pipenv run py.test -v test
+before_deploy:
+- sed -i.bak "s/=get_version()/='$TRAVIS_TAG'/g" setup.py
+- cat setup.py
+- if [ $(python setup.py --version) == '0.0.0' ]; then travis_terminate 1; fi
+deploy:
+  provider: pypi
+  user: uc-ctds
+  skip_existing: true
+  skip_cleanup: true
+  on:
+    python: 2.7
+    repo: uc-cdis/psqlgraph
+    tags: true
+    branch: develop
+  password:
+    secure: hiSe0K4dZSeQyx0NUI79STVKyaGupuJIuvkAWmyky0OX2YzKta6hanyJEIkWLHq0465Z6GJV1qLPZB5pYCjJyEXuGMu5yjdBMqyGvdjXBt8A4BFlesKJXe1ljS+u3JoOZKMqUUrGqxfdxfcxnfo9hXwG06gQqdjxMAMgMCaikAA5mhg58eZV12bcBTwPLvIhQ7qt2EABahBms7Udi0OY6oQMUJ9L3I/7FXLF4CRRaf+UdZHgDz7TdFEq0h2yxUNtaKyJFzsDffQfu6lYn/Pue7nF9HDsWGO7zZOrNkflw9cWoHlFOQjrG/OMUDmZ0Nf3oKm+CfQM51FKkRMINlgsUGnHeVmm1xJ+LGTMmBuUXuTDkOsNbmbmQ3YT0aoJOYqMmm7QjlyuvFGM1hx0Vrw/4BHP8p0Uz/R1mnhfnOOuDWw3Tqj8Y6dZsR5kO8NX0RG3V5VQXz4ABiYDx2/P41zW4qChni5uq4NPnktfrFkRVKR9gbfGqUVhmSiAZqM1MGZpmNwJ5tASYnhPa+gVTLQCR9yQQ+qqMpD9kTZZMremWibvWfHrq4OQvQOuMOdNjxuE+3vdQkO68VtqiIl/qAvReGNA/y9ky5P4fQDYwmNRcVXOrKpS7L5rZbriATBWSZhOmmFrh735UZ6er6i9pgqMrP2mA8wW1lxIFGdHCBcDzZU=
+env:
+  global:
+  - PIPENV_IGNORE_VIRTUALENVS=1
+  - secure: OADcVWEZgkVtRduIDbuyXBVBoEeJJCJZ/yGqLK+uU4ziM+CJ7AxEHbOgKENpkbUXEvrTz1CnNt//CAKGXZnPU0mBLvCB0sD1WvO3ITNcufqxUBceEAyrrjMEwrQ51fHTSzWxfaHYcqFGsxHonHOsS/hLuRshgGgc8HT5Yu39WBtiTG6SCvKAsq7GYuk4PQ6vK44g5YVZqzur9zyXcUdFmv+GBBHVfXlTGwzd9CMfx+o0sqpD9KcAxMCIfoxL/ReGM3KihFy+WgID9gmlH6tq18RnKrtLZbHgPO5395HPZoKpy+HWJtCOf1Q/luvCPo+DI4LYhU9o/WOOSPK4hb06IUOMYlxDf0LKo3P85P2lGhM3RLpiKF6+YB+EjLdld1LCFHPMRi3QG6pUAH6Jg3+9Iko3ry2QCNFMGxOmfdc8vYefXanSi7++MxevKONQdAb2rcz+XK/5bLXWWzPbs4QC0y+c6GzcayQwHDrlrf5kvHBC27zy/kW8oW7iQlN+4UgddZeUBjiSm7bdWNt2D1r522vMz6W+9JU3dNLcHoBiNm3dJVFbOV3RX4RaJdNnUUX9FMeS4xpBV1/keR2d3wZxFQjf4/uQq6/crOtBExtxwaZSPt+R0/JRCtQcQYxU9uum2ezVmFhjzFkKgsW3dDVQFja9Hxp1bc0G/tBs2vfhlUc=
+after_deploy:
+- pipenv run pip install gen3git
+- pipenv run gen3git release

--- a/Pipfile
+++ b/Pipfile
@@ -7,6 +7,7 @@ verify_ssl = true
 
 [packages]
 psqlgraph = {path = ".",editable = true}
+pytest = "*"
 
 [requires]
 python_version = "2.7"

--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,12 @@
+[[source]]
+name = "pypi"
+url = "https://pypi.org/simple"
+verify_ssl = true
+
+[dev-packages]
+
+[packages]
+psqlgraph = {path = ".",editable = true}
+
+[requires]
+python_version = "2.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "55a2d760c16d4c1a880338de61795d5892420d3722299edd78dd4e07b33c25c0"
+            "sha256": "291117199dce374e87a76da15459c44e0de0d77341c0fd1abffae473786b62bc"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -16,6 +16,20 @@
         ]
     },
     "default": {
+        "atomicwrites": {
+            "hashes": [
+                "sha256:03472c30eb2c5d1ba9227e4c2ca66ab8287fbfbbda3888aa93dc2e28fc6811b4",
+                "sha256:75a9445bac02d8d058d5e1fe689654ba5a6556a1dfd8ce6ec55a0ed79866cfa6"
+            ],
+            "version": "==1.3.0"
+        },
+        "attrs": {
+            "hashes": [
+                "sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79",
+                "sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399"
+            ],
+            "version": "==19.1.0"
+        },
         "avro": {
             "hashes": [
                 "sha256:5eace17f1740cfb4c6246de162ed2f8366647eb5a962b919189b0c8a9913c729"
@@ -36,12 +50,74 @@
             ],
             "version": "==3.0.4"
         },
+        "configparser": {
+            "hashes": [
+                "sha256:8be81d89d6e7b4c0d4e44bcc525845f6da25821de80cb5e06e7e0238a2899e32",
+                "sha256:da60d0014fd8c55eb48c1c5354352e363e2d30bbf7057e5e171a468390184c75"
+            ],
+            "markers": "python_version < '3'",
+            "version": "==3.7.4"
+        },
+        "contextlib2": {
+            "hashes": [
+                "sha256:509f9419ee91cdd00ba34443217d5ca51f5a364a404e1dce9e8979cea969ca48",
+                "sha256:f5260a6e679d2ff42ec91ec5252f4eeffdcf21053db9113bd0a8e4d953769c00"
+            ],
+            "markers": "python_version < '3'",
+            "version": "==0.5.5"
+        },
+        "funcsigs": {
+            "hashes": [
+                "sha256:330cc27ccbf7f1e992e69fef78261dc7c6569012cf397db8d3de0234e6c937ca",
+                "sha256:a7bb0f2cf3a3fd1ab2732cb49eba4252c2af4240442415b4abce3b87022a8f50"
+            ],
+            "markers": "python_version < '3.0'",
+            "version": "==1.0.2"
+        },
         "idna": {
             "hashes": [
                 "sha256:c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407",
                 "sha256:ea8b7f6188e6fa117537c3df7da9fc686d485087abf6ac197f9c46432f7e4a3c"
             ],
             "version": "==2.8"
+        },
+        "importlib-metadata": {
+            "hashes": [
+                "sha256:6dfd58dfe281e8d240937776065dd3624ad5469c835248219bd16cf2e12dbeb7",
+                "sha256:cb6ee23b46173539939964df59d3d72c3e0c1b5d54b84f1d8a7e912fe43612db"
+            ],
+            "version": "==0.18"
+        },
+        "more-itertools": {
+            "hashes": [
+                "sha256:38a936c0a6d98a38bcc2d03fdaaedaba9f412879461dd2ceff8d37564d6522e4",
+                "sha256:c0a5785b1109a6bd7fac76d6837fd1feca158e54e521ccd2ae8bfe393cc9d4fc",
+                "sha256:fe7a7cae1ccb57d33952113ff4fa1bc5f879963600ed74918f1236e212ee50b9"
+            ],
+            "markers": "python_version <= '2.7'",
+            "version": "==5.0.0"
+        },
+        "packaging": {
+            "hashes": [
+                "sha256:0c98a5d0be38ed775798ece1b9727178c4469d9c3b4ada66e8e6b7849f8732af",
+                "sha256:9e1cbf8c12b1f1ce0bb5344b8d7ecf66a6f8a6e91bcb0c84593ed6d3ab5c4ab3"
+            ],
+            "version": "==19.0"
+        },
+        "pathlib2": {
+            "hashes": [
+                "sha256:25199318e8cc3c25dcb45cbe084cc061051336d5a9ea2a12448d3d8cb748f742",
+                "sha256:5887121d7f7df3603bca2f710e7219f3eca0eb69e0b7cc6e0a022e155ac931a7"
+            ],
+            "markers": "python_version == '3.4.*' or python_version < '3'",
+            "version": "==2.3.3"
+        },
+        "pluggy": {
+            "hashes": [
+                "sha256:0825a152ac059776623854c1543d65a4ad408eb3d33ee114dff91e57ec6ae6fc",
+                "sha256:b9817417e95936bf75d85d3f8767f7df6cdde751fc40aed3bb3074cbcb77757c"
+            ],
+            "version": "==0.12.0"
         },
         "progressbar": {
             "hashes": [
@@ -69,11 +145,33 @@
             ],
             "version": "==2.8.3"
         },
+        "py": {
+            "hashes": [
+                "sha256:64f65755aee5b381cea27766a3a147c3f15b9b6b9ac88676de66ba2ae36793fa",
+                "sha256:dc639b046a6e2cff5bbe40194ad65936d6ba360b52b3c3fe1d08a82dd50b5e53"
+            ],
+            "version": "==1.8.0"
+        },
         "py2neo": {
             "hashes": [
                 "sha256:5fada4fbd5587c071912525ed4482b61f49a191e4588f3117425546e81206168"
             ],
             "version": "==2.0.9"
+        },
+        "pyparsing": {
+            "hashes": [
+                "sha256:1873c03321fc118f4e9746baf201ff990ceb915f433f23b395f5580d1840cb2a",
+                "sha256:9b6323ef4ab914af344ba97510e966d64ba91055d6b9afa6b30799340e89cc03"
+            ],
+            "version": "==2.4.0"
+        },
+        "pytest": {
+            "hashes": [
+                "sha256:4a784f1d4f2ef198fe9b7aef793e9fa1a3b2f84e822d9b3a64a181293a572d45",
+                "sha256:926855726d8ae8371803f7b2e6ec0a69953d9c6311fa7c3b6c1b929ff92d27da"
+            ],
+            "index": "pypi",
+            "version": "==4.6.3"
         },
         "requests": {
             "hashes": [
@@ -81,6 +179,30 @@
                 "sha256:9cf5292fcd0f598c671cfc1e0d7d1a7f13bb8085e9a590f48c010551dc6c4b31"
             ],
             "version": "==2.22.0"
+        },
+        "scandir": {
+            "hashes": [
+                "sha256:2586c94e907d99617887daed6c1d102b5ca28f1085f90446554abf1faf73123e",
+                "sha256:2ae41f43797ca0c11591c0c35f2f5875fa99f8797cb1a1fd440497ec0ae4b022",
+                "sha256:2b8e3888b11abb2217a32af0766bc06b65cc4a928d8727828ee68af5a967fa6f",
+                "sha256:2c712840c2e2ee8dfaf36034080108d30060d759c7b73a01a52251cc8989f11f",
+                "sha256:4d4631f6062e658e9007ab3149a9b914f3548cb38bfb021c64f39a025ce578ae",
+                "sha256:67f15b6f83e6507fdc6fca22fedf6ef8b334b399ca27c6b568cbfaa82a364173",
+                "sha256:7d2d7a06a252764061a020407b997dd036f7bd6a175a5ba2b345f0a357f0b3f4",
+                "sha256:8c5922863e44ffc00c5c693190648daa6d15e7c1207ed02d6f46a8dcc2869d32",
+                "sha256:92c85ac42f41ffdc35b6da57ed991575bdbe69db895507af88b9f499b701c188",
+                "sha256:b24086f2375c4a094a6b51e78b4cf7ca16c721dcee2eddd7aa6494b42d6d519d",
+                "sha256:cb925555f43060a1745d0a321cca94bcea927c50114b623d73179189a4e100ac"
+            ],
+            "markers": "python_version < '3.5'",
+            "version": "==1.10.0"
+        },
+        "six": {
+            "hashes": [
+                "sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c",
+                "sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
+            ],
+            "version": "==1.12.0"
         },
         "sqlalchemy": {
             "hashes": [
@@ -95,11 +217,25 @@
             ],
             "version": "==1.25.3"
         },
+        "wcwidth": {
+            "hashes": [
+                "sha256:3df37372226d6e63e1b1e1eda15c594bca98a22d33a23832a90998faa96bc65e",
+                "sha256:f4ebe71925af7b40a864553f761ed559b43544f8f71746c2d756c7fe788ade7c"
+            ],
+            "version": "==0.1.7"
+        },
         "xlocal": {
             "hashes": [
                 "sha256:8ee1c1551294e366a3c307985ea2129e72717556a5736063c0e089c5fb868405"
             ],
             "version": "==0.5"
+        },
+        "zipp": {
+            "hashes": [
+                "sha256:8c1019c6aad13642199fbe458275ad6a84907634cc9f0989877ccc4a2840139d",
+                "sha256:ca943a7e809cc12257001ccfb99e3563da9af99d52f261725e96dfe0f9275bc3"
+            ],
+            "version": "==0.5.1"
         }
     },
     "develop": {}

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,0 +1,106 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "55a2d760c16d4c1a880338de61795d5892420d3722299edd78dd4e07b33c25c0"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "2.7"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "avro": {
+            "hashes": [
+                "sha256:5eace17f1740cfb4c6246de162ed2f8366647eb5a962b919189b0c8a9913c729"
+            ],
+            "version": "==1.9.0"
+        },
+        "certifi": {
+            "hashes": [
+                "sha256:046832c04d4e752f37383b628bc601a7ea7211496b4638f6514d0e5b9acc4939",
+                "sha256:945e3ba63a0b9f577b1395204e13c3a231f9bc0223888be653286534e5873695"
+            ],
+            "version": "==2019.6.16"
+        },
+        "chardet": {
+            "hashes": [
+                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",
+                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
+            ],
+            "version": "==3.0.4"
+        },
+        "idna": {
+            "hashes": [
+                "sha256:c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407",
+                "sha256:ea8b7f6188e6fa117537c3df7da9fc686d485087abf6ac197f9c46432f7e4a3c"
+            ],
+            "version": "==2.8"
+        },
+        "progressbar": {
+            "hashes": [
+                "sha256:5d81cb529da2e223b53962afd6c8ca0f05c6670e40309a7219eacc36af9b6c63"
+            ],
+            "version": "==2.5"
+        },
+        "psqlgraph": {
+            "editable": true,
+            "path": "."
+        },
+        "psycopg2": {
+            "hashes": [
+                "sha256:128d0fa910ada0157bba1cb74a9c5f92bb8a1dca77cf91a31eb274d1f889e001",
+                "sha256:227fd46cf9b7255f07687e5bde454d7d67ae39ca77e170097cdef8ebfc30c323",
+                "sha256:2315e7f104681d498ccf6fd70b0dba5bce65d60ac92171492bfe228e21dcc242",
+                "sha256:4b5417dcd2999db0f5a891d54717cfaee33acc64f4772c4bc574d4ff95ed9d80",
+                "sha256:640113ddc943522aaf71294e3f2d24013b0edd659b7820621492c9ebd3a2fb0b",
+                "sha256:897a6e838319b4bf648a574afb6cabcb17d0488f8c7195100d48d872419f4457",
+                "sha256:8dceca81409898c870e011c71179454962dec152a1a6b86a347f4be74b16d864",
+                "sha256:b1b8e41da09a0c3ef0b3d4bb72da0dde2abebe583c1e8462973233fd5ad0235f",
+                "sha256:cb407fccc12fc29dc331f2b934913405fa49b9b75af4f3a72d0f50f57ad2ca23",
+                "sha256:d3a27550a8185e53b244ad7e79e307594b92fede8617d80200a8cce1fba2c60f",
+                "sha256:f0e6b697a975d9d3ccd04135316c947dd82d841067c7800ccf622a8717e98df1"
+            ],
+            "version": "==2.8.3"
+        },
+        "py2neo": {
+            "hashes": [
+                "sha256:5fada4fbd5587c071912525ed4482b61f49a191e4588f3117425546e81206168"
+            ],
+            "version": "==2.0.9"
+        },
+        "requests": {
+            "hashes": [
+                "sha256:11e007a8a2aa0323f5a921e9e6a2d7e4e67d9877e85773fba9ba6419025cbeb4",
+                "sha256:9cf5292fcd0f598c671cfc1e0d7d1a7f13bb8085e9a590f48c010551dc6c4b31"
+            ],
+            "version": "==2.22.0"
+        },
+        "sqlalchemy": {
+            "hashes": [
+                "sha256:c30925d60af95443458ebd7525daf791f55762b106049ae71e18f8dd58084c2f"
+            ],
+            "version": "==1.3.5"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:b246607a25ac80bedac05c6f282e3cdaf3afb65420fd024ac94435cabe6e18d1",
+                "sha256:dbe59173209418ae49d485b87d1681aefa36252ee85884c31346debd19463232"
+            ],
+            "version": "==1.25.3"
+        },
+        "xlocal": {
+            "hashes": [
+                "sha256:8ee1c1551294e366a3c307985ea2129e72717556a5736063c0e089c5fb868405"
+            ],
+            "version": "==0.5"
+        }
+    },
+    "develop": {}
+}

--- a/setup.py
+++ b/setup.py
@@ -1,16 +1,31 @@
+from subprocess import check_output
 from setuptools import setup
 
+def get_version():
+    # https://github.com/uc-cdis/dictionaryutils/pull/37#discussion_r257898408
+    try:
+        tag = check_output(
+            ["git", "describe", "--tags", "--abbrev=0", "--match=[0-9]*"]
+        )
+        return tag.decode("utf-8").strip("\n")
+    except Exception:
+        raise RuntimeError(
+            "The version number cannot be extracted from git tag in this source "
+            "distribution; please either download the source from PyPI, or check out "
+            "from GitHub and make sure that the git CLI is available."
+        )
+
 setup(
-    version='2.0.1',
     name='psqlgraph',
+    version=get_version(),
     packages=["psqlgraph"],
     install_requires=[
-        'psycopg2==2.7.3.2',
+        'psycopg2~=2.7',
         'sqlalchemy~=1.3',
-        'py2neo==2.0.1',
+        'py2neo~=2.0',
         'progressbar',
-        'avro==1.7.7',
-        'xlocal==0.5',
-        'requests>=2.5.2, <=2.7.0'
+        'avro~=1.7',
+        'xlocal~=0.5',
+        'requests~=2.5'
     ]
 )


### PR DESCRIPTION
Release to PyPI ~and automate release notes~ 

### Improvements
- Use pipenv/ add Pipfile and Pipfile.lock 
- Use loose pins in setup.py

### Deployment changes
- Auto deploy to PyPI
- Package version no longer hardcoded
- Add section to automate release notes using gen3git, but this is temporarily disabled because gen3git gets confused by the current tag numbers

